### PR TITLE
Perf/malloc

### DIFF
--- a/bindgen/src/lib.rs
+++ b/bindgen/src/lib.rs
@@ -86,3 +86,10 @@ impl<T: FromLibSQL> FromLibSQL for Option<T> {
         }
     }
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn libsql_malloc(size: usize) -> usize {
+    let buffer = Vec::<u8>::with_capacity(size);
+    let ptr = Vec::leak(buffer);
+    ptr.as_ptr() as usize
+}

--- a/examples/src/concat.rs
+++ b/examples/src/concat.rs
@@ -1,7 +1,6 @@
-use libsql_bindgen::libsql_bindgen;
-use libsql_wasm_abi::*;
+use libsql_bindgen::*;
 
-#[libsql_bindgen]
+#[libsql_bindgen::libsql_bindgen]
 pub fn concat(s1: String, s2: String) -> String {
     let mut ret = s1.clone();
     ret += &s2;


### PR DESCRIPTION
This Pull Request adds support for host memory allocation in the `libsql_malloc` function.  The updated function allows allocating memory in a WebAssembly module from the host environment by using the memory object provided by the WebAssembly Instance. 

The corresponding modification for libsql can be found here: https://github.com/libsql/libsql/pull/145.