### PR TITLE
Feat/return blob

### DIFF
--- a/bindgen/src/lib.rs
+++ b/bindgen/src/lib.rs
@@ -74,6 +74,18 @@ impl FromLibSQL for &mut [u8] {
     }
 }
 
+impl IntoLibSQL for Vec<u8> {
+    fn into_libsql_type(self) -> i32 {
+        let mut mem: Vec<u8> = vec![0; self.len() + 5];
+        mem[0] = SQLITE_BLOB;
+        mem[1..5].copy_from_slice(&u32::to_be_bytes(self.len() as u32));
+        mem[5..].copy_from_slice(&self);
+        let ptr = mem.as_ptr() as i32;
+        std::mem::forget(mem);
+        ptr
+    }
+}
+
 impl<T: FromLibSQL> FromLibSQL for Option<T> {
     fn from_libsql_type(wasm_ptr: i32) -> Self {
         let raw_ptr = wasm_ptr as *const c_char;

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,3 +10,16 @@ libsql_bindgen = { path = "../bindgen" }
 [[example]]
 name = "concat"
 path = "src/concat.rs"
+
+[[example]]
+name = "concat3"
+path = "src/concat3.rs"
+
+
+[[example]]
+name = "contains"
+path = "src/contains.rs"
+
+[[example]]
+name = "reverse_blob"
+path = "src/reverse_blob.rs"

--- a/examples/src/concat3.rs
+++ b/examples/src/concat3.rs
@@ -1,0 +1,11 @@
+use libsql_bindgen::*;
+
+#[libsql_bindgen::libsql_bindgen]
+pub fn concat3(s1: String, s2: String, s3: String) -> String {
+    let mut ret = s1.clone();
+    ret += &s2;
+    ret += &s3;
+    ret
+}
+
+fn main() {}

--- a/examples/src/contains.rs
+++ b/examples/src/contains.rs
@@ -1,0 +1,8 @@
+use libsql_bindgen::*;
+
+#[libsql_bindgen::libsql_bindgen]
+pub fn contains(s1: String, s2: String) -> bool {
+    s1.contains(&s2)
+}
+
+fn main() {}

--- a/examples/src/reverse_blob.rs
+++ b/examples/src/reverse_blob.rs
@@ -1,0 +1,10 @@
+use libsql_bindgen::*;
+
+#[libsql_bindgen::libsql_bindgen]
+pub fn reverse_blob(blob: &mut [u8]) -> Vec<u8> {
+    let mut r = blob.to_vec();
+    r.reverse();
+    r
+}
+
+fn main() {}


### PR DESCRIPTION
* I noticed that the method for returning `BLOB` was not supported, so I implemented `IntoLibSQL` for `Vec<u8>` to support returning `BLOB`.
* I have added some Wasm files for testing in https://github.com/libsql/libsql/pull/145. Here are their source codes so that others can recompile them if needed.